### PR TITLE
Manually bump version to avoid clash on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balena/compose",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Complete toolkit to build docker-compose.yml files and optionally deploy them to balenaCloud",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
`@balena/compose` has been used for POC about a year ago and had releases up to v1.0.0.

Change-type: major