### PR TITLE
Fix release models compile, and test failure from dependency regression

### DIFF
--- a/lib/release/models.ts
+++ b/lib/release/models.ts
@@ -1,5 +1,9 @@
 import type { PinejsClientRequest } from 'pinejs-client-request';
-import type { Expand, Filter, ODataOptions } from 'pinejs-client-core';
+import type {
+	Expand,
+	Filter,
+	ODataOptions,
+} from 'pinejs-client-core';
 
 import type { Composition } from '../../lib/parse';
 

--- a/lib/release/models.ts
+++ b/lib/release/models.ts
@@ -95,7 +95,7 @@ export interface ReleaseImageModel extends ReleaseImageAttributesBase {
 
 // Helpers
 
-export function getOrCreate<T, U, V extends Filter>(
+export function getOrCreate<T, U extends {}, V extends Filter>(
 	api: PinejsClientRequest,
 	resource: string,
 	body: U,
@@ -114,7 +114,7 @@ export function getOrCreate<T, U, V extends Filter>(
 	}) as Promise<T>;
 }
 
-export function create<T, U>(
+export function create<T, U extends {}>(
 	api: PinejsClientRequest,
 	resource: string,
 	body: U,
@@ -122,7 +122,7 @@ export function create<T, U>(
 	return api.post({ resource, body }).catch(wrapResponseError) as Promise<T>;
 }
 
-export function update<T>(
+export function update<T extends {}>(
 	api: PinejsClientRequest,
 	resource: string,
 	id: number,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "docker-modem": "^3.0.3",
     "docker-progress": "^5.1.0",
     "dockerfile-ast": "^0.2.1",
-    "dockerode": "^3.3.1",
+    "dockerode": "3.3.3",
     "duplexify": "^4.1.2",
     "event-stream": "^4.0.1",
     "fp-ts": "^2.8.1",


### PR DESCRIPTION
See issue below for details on compilation failure. Also includes a cosmetic fix from prettify.

This fix minimally narrows the `body` input parameters by keeping them generics. It would be simpler to directly describe the body parameters as AnyObject without the generics, but I don't have enough context to know if that solution is better.

The test failure is due to a regression in dockerode v3.3.4, as described in [this issue](https://github.com/apocas/dockerode/issues/696). We have proposed a [fix PR](https://github.com/apocas/dockerode/issues/696). While waiting for a response, this PR pins dockerode to v3.3.3.

Fixes #10 , #15