### PR TITLE
Allow most printable ASCII chars for object label key (b-c)

### DIFF
--- a/lib/parse/compose.ts
+++ b/lib/parse/compose.ts
@@ -486,11 +486,11 @@ function validateServiceVolume(
 
 function validateLabels(labels: Dict<string>) {
 	_.keys(labels).forEach((name) => {
-		if (!/^[a-zA-Z0-9.-]+$/.test(name)) {
+		if (!/^[!#-&(-_a-~]+$/.test(name)) {
 			throw new ValidationError(
 				`Invalid label name: "${name}". ` +
-					'Label names must only contain alphanumeric ' +
-					'characters, periods "." and dashes "-".',
+					'Label names may contain printable ASCII characters ' +
+					'except space, single/double quotes and backtick',
 			);
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/bluebird": "^3.5.32",
     "@types/chai-as-promised": "^7.1.3",
     "@types/docker-modem": "^3.0.1",
-    "@types/dockerode": "^3.3.8",
+    "@types/dockerode": "^3.3.11",
     "@types/duplexify": "^3.6.1",
     "@types/event-stream": "^4.0.0",
     "@types/js-yaml": "^4.0.1",

--- a/test/parse/all.spec.ts
+++ b/test/parse/all.spec.ts
@@ -203,6 +203,24 @@ describe('validation', () => {
 		}
 	});
 
+	it('label name accepts legal characters', (done) => {
+		const f = () => {
+			compose.normalize({
+				version: '2.1',
+				services: {
+					main: {
+						image: 'some/image',
+						labels: {
+							'@not.mal_formed': 'true',
+						},
+					},
+				},
+			});
+		};
+		expect(f).not.to.throw();
+		done();
+	});
+
 	it('should throw if label name contains forbidden characters', (done) => {
 		const f = () => {
 			compose.normalize({
@@ -211,13 +229,13 @@ describe('validation', () => {
 					main: {
 						image: 'some/image',
 						labels: {
-							mal_formed: 'true',
+							'mal"formed': 'true',
 						},
 					},
 				},
 			});
 		};
-		expect(f).to.throw('Invalid label name: "mal_formed"');
+		expect(f).to.throw('Invalid label name: "mal"formed"');
 		done();
 	});
 


### PR DESCRIPTION
## Ensure all dependents of this package work before merging this PR!

Extends acceptable label characters to printable ASCII characters except space, single/double quotes and backtick. Updates minimal acceptable version of @types/dockerode to ensure build succeeds.

As of 2023-03-22 this PR still is blocked on an overall system solution between clients and server. This PR is useful; however older clients likely will fail in some way if they receive a service containing the extra characters.

Fixes #12