### PR TITLE
Do not set target platform unless directed

### DIFF
--- a/lib/multibuild/build-task.ts
+++ b/lib/multibuild/build-task.ts
@@ -122,17 +122,10 @@ export interface BuildTask {
 
 	/**
 	 * The platform string used used by docker resolve the correct
-	 * image in manifest lists.
-	 * Populated in the resolution step by translating from the
-	 * architecture property unless `useDefaultPlatformOnly` is `true`.
+	 * image in manifest lists. To use the host docker daemon
+	 * architecture, this should unset or empty.
 	 */
 	dockerPlatform?: string;
-
-	/**
-	 * If true, then do not attempt to query base image manifests for
-	 * a matching platform. The default platform (builder arch) will be used.
-	 */
-	useDefaultPlatformForMultiarchBaseImages?: boolean;
 
 	/**
 	 * The container contract for this service

--- a/lib/multibuild/build.ts
+++ b/lib/multibuild/build.ts
@@ -28,7 +28,6 @@ import { BuildProcessError } from './errors';
 import { pullExternal } from './external';
 import { LocalImage } from './local-image';
 import type { RegistrySecrets } from './registry-secrets';
-import { getManifest, MEDIATYPE_MANIFEST_LIST_V2 } from './manifests';
 
 function taskHooks(
 	task: BuildTask,
@@ -126,16 +125,20 @@ export async function runBuildTask(
 	//
 	// * _ Do the images support it? _
 	//   In order to support `platform`, all images used in the Dockerfile must use the same
-	//   architecture.  Determining this is problematic.  See comments in getRecommendedPlatformHandling
+	//   architecture.  Determining this is problematic.  See comments in checkAllowDockerPlatformHandling
 
 	const usePlatformOption: boolean =
 		!!task.dockerPlatform &&
 		semver.satisfies(
 			semver.coerce((await docker.version()).ApiVersion) || '0.0.0',
 			'>=1.38.0',
-		) &&
-		(task.useDefaultPlatformForMultiarchBaseImages === true ||
-			(await checkAllowDockerPlatformHandling(task, docker)));
+		);
+
+	if (task.dockerPlatform) {
+		task.logger?.debug(
+			`${task.serviceName}: Setting target platform to ${task.dockerPlatform}`,
+		);
+	}
 
 	task.dockerOpts = _.merge(
 		usePlatformOption ? { platform: task.dockerPlatform } : {},
@@ -195,153 +198,4 @@ export async function runBuildTask(
 			builder.createBuildStream(dockerOpts, hooks, reject);
 		});
 	});
-}
-
-//   This method attempts to calculate if we should pass the `platform` flag to Docker, or
-//   not.
-//
-///  The complexity arises from the fact that old v1 manifests do not describe platform.
-//   In such cases, Docker will assume the image matches the platform of the current machine.
-//
-//   When Docker receives a target platform, these are the possible cases:
-//
-//      + V2 manifest/list for all images, and all images support the requested arch
-//        Note that "support" means either it is a single arch image with the correct arch
-//        or else it is a multi-arch image with one of the images matching arch
-//          -> Result: Good to go
-//
-//      + V2 manifest/list for all images, and some do not support the requested arch
-//          -> Result: Docker error
-//
-//      + Some V1 manifests, the platform flag matches what Docker guesses
-//          -> Result:  Docker will succeed if the guesses are correct or fail with
-//                      execution error if one of the guesses is wrong.
-//
-//      + Some V1 manifests, platform flag does not match what Docker guesses
-//          -> Result:  Docker will throw an error even if the images are actually the
-//                      correct architecture, because its guesses are wrong.
-//
-//   When Docker does not receive the `platform` flag, it sort of closes its eyes and hopes
-//   for the best.  It has to do this in order to maintain backwards-compatible behavior:
-//
-//      + V2 manifests for all images: If using multiarch images, Docker will
-//        infer the platform from where the build engine is running.  If using single arch
-//        images, Docker will assume the declared image arch is the correct platform.
-//          -> Result: Docker builds, with a warning if the images do not match the
-//                     current platform.
-//
-//      + Some V1 manifests:
-//          -> Result: Docker builds, assuming that the platform matches where the build
-//                     is occurring.
-//
-//      NOTE!  Even when a build succeeds, if Docker is making assumptions then it is possible that
-//      the image will cause an execution error on the target platform if the architecture is not
-//      correct.
-//
-//   So what do we do?
-//
-//      + In the case of all images having a V2 manifest, we can simply pass the platform flag.
-//
-//      + In the case of having some V1 manifests, don't pass the platform flag.  Warn, but
-//        let Docker close its eyes and hope for the best.  This opens the possibility for an
-//        exec error, but also allows users to continue to use v1 images if they want to / need to.
-//
-async function checkAllowDockerPlatformHandling(
-	task: BuildTask,
-	docker: Dockerode,
-): Promise<boolean> {
-	const imageReferences: string[] = [];
-
-	const debug = task.logger ? task.logger.debug : () => undefined;
-	const warn = task.logger ? task.logger.warn : () => undefined;
-
-	const checkHasPlatformInfo = async (repository: string) => {
-		try {
-			const manifest = await getManifest(docker.modem, repository);
-			return manifest.Descriptor.mediaType === MEDIATYPE_MANIFEST_LIST_V2;
-		} catch {
-			// eat the exception... yummy!
-		}
-
-		debug(
-			`${task.serviceName}: Image manifest data unavailable for ${repository}`,
-		);
-		// at this time, treat any errors as false (no platform support)
-		return false;
-	};
-
-	if (task.imageName) {
-		imageReferences.push(task.imageName);
-	} else {
-		if (!task.dockerfile) {
-			// Sanity check
-			debug(
-				`${task.serviceName}: Build task does not have an associated Dockerfile`,
-			);
-			return false;
-		}
-		const { DockerfileParser } = await import('dockerfile-ast');
-		const parsedDockerfile = DockerfileParser.parse(task.dockerfile);
-		const dockerInstructions = parsedDockerfile.getInstructions();
-		const fromInstructions = dockerInstructions.filter(
-			(inst) => inst.getKeyword() === 'FROM',
-		);
-		if (fromInstructions.length === 0) {
-			// Sanity check
-			debug(`${task.serviceName}: Dockerfile does not reference any images`);
-			return false;
-		}
-		for (const inst of fromInstructions) {
-			for (const arg of inst.getArguments()) {
-				const val = arg.getValue();
-				if (!val.startsWith('--')) {
-					imageReferences.push(val);
-					break;
-				}
-			}
-		}
-	}
-
-	const imagesWithoutPlatformSupport: string[] = [];
-	const imagesWithPlatformSupport: string[] = [];
-
-	await Promise.all(
-		imageReferences.map(async (r) => {
-			const hasPlatformSupport = await checkHasPlatformInfo(r);
-			if (hasPlatformSupport) {
-				imagesWithPlatformSupport.push(r);
-			} else {
-				imagesWithoutPlatformSupport.push(r);
-			}
-		}),
-	);
-
-	if (imagesWithoutPlatformSupport.length === 0) {
-		// All images specify platform, let Docker receive `--platform`
-		return true;
-	} else if (imagesWithPlatformSupport.length > 0) {
-		// Here we know that the service references at least 2 images
-		// (at least 1 with platform support and at least 1 without platform
-		// support). Therefore the service is not an "external image service"
-		// (`task.imageName` must be falsy), and it must have a multi-stage
-		// Dockerfile that references at least 2 images.
-		warn(`\
-Service '${task.serviceName}':
-  Multi-stage Dockerfile found with a mix of base images that require
-  CPU architecture selection and base images that do not support it.
-  The following base images do not support CPU architecture selection:
-  - ${imagesWithoutPlatformSupport.join('\n  - ')}
-  The following base images require CPU architecture selection:
-  - ${imagesWithPlatformSupport.join('\n  - ')}
-  As a result, the CPU architecture of the machine where the Docker Engine
-  is running will be used by default to select base images that require
-  architecture selection. This may result in incorrect architecture selection
-  and "exec format error" at runtime. It is usually possible to override the
-  architecture in the FROM line with e.g. "FROM --platform=linux/arm/v7",
-  or by adding the sha256 digest of the image for a specific architecture
-  with e.g. "FROM debian@sha256:094f57...".`);
-	}
-
-	// Proceeding after warnings.  Docker will _not_ receive `--platform`
-	return false;
 }

--- a/lib/multibuild/resolve.ts
+++ b/lib/multibuild/resolve.ts
@@ -45,12 +45,6 @@ export function resolveTask(
 	additionalVars: Dictionary<string> = {},
 	dockerfilePreprocessHook?: (content: string) => string,
 ): BuildTask {
-	// set the platform / architecture for pulling multiarch images
-	const platform = resolveDockerPlatform(architecture);
-	if (platform) {
-		task.dockerPlatform = platform;
-	}
-
 	if (task.external) {
 		// No resolution needs to be performed for external images
 		return task;

--- a/lib/release/models.ts
+++ b/lib/release/models.ts
@@ -1,9 +1,5 @@
 import type { PinejsClientRequest } from 'pinejs-client-request';
-import type {
-	Expand,
-	Filter,
-	ODataOptions,
-} from 'pinejs-client-core';
+import type { Expand, Filter, ODataOptions } from 'pinejs-client-core';
 
 import type { Composition } from '../../lib/parse';
 

--- a/test/multibuild/build.spec.ts
+++ b/test/multibuild/build.spec.ts
@@ -248,6 +248,7 @@ describe('Resolved project building', () => {
 			streamHook: streamPrinter,
 			buildMetadata,
 			dockerOpts: { pull: true },
+			dockerPlatform: 'linux/386',
 		};
 		return new Promise<LocalImage>((resolve, reject) => {
 			const resolveListeners = {

--- a/test/multibuild/resolve.spec.ts
+++ b/test/multibuild/resolve.spec.ts
@@ -108,35 +108,4 @@ describe('Project resolution', () => {
 			newTask.buildStream.resume();
 		});
 	});
-
-	it('should correctly resolve the target platform', () => {
-		const task: BuildTask = {
-			external: false,
-			resolved: false,
-			buildStream: fs.createReadStream(
-				`${TEST_FILES_PATH}/templateProject.tar`,
-			) as any as Pack,
-			serviceName: 'test',
-			buildMetadata,
-		};
-
-		return new Promise<void>((resolve, reject) => {
-			const resolveListeners = {
-				error: [reject],
-				end: [
-					() => {
-						try {
-							expect(newTask.dockerPlatform).to.equal('linux/386');
-							expect(newTask.resolved).to.equal(true);
-							resolve();
-						} catch (error) {
-							reject(error);
-						}
-					},
-				],
-			};
-			const newTask = resolveTask(task, 'i386', 'test', resolveListeners);
-			newTask.buildStream.resume();
-		});
-	});
 });


### PR DESCRIPTION
Avoid setting docker target platform unless the calling function has specified one. In general this should only be required for emulated builds.

Change-type: minor
Resolves: https://github.com/balena-io/balena-builder/issues/1008
See: https://balena.zulipchat.com/#narrow/stream/345882-_help/topic/failed.20to.20get.20destination.20image.20when.20using.20old.20images