### PR TITLE
OCI Image Index should allow platform opts

### DIFF
--- a/lib/multibuild/build.ts
+++ b/lib/multibuild/build.ts
@@ -28,7 +28,11 @@ import { BuildProcessError } from './errors';
 import { pullExternal } from './external';
 import { LocalImage } from './local-image';
 import type { RegistrySecrets } from './registry-secrets';
-import { getManifest, MEDIATYPE_MANIFEST_LIST_V2 } from './manifests';
+import {
+	getManifest,
+	MEDIATYPE_MANIFEST_LIST_V2,
+	MEDIATYPE_OCI_IMAGE_INDEX_V1,
+} from './manifests';
 
 function taskHooks(
 	task: BuildTask,
@@ -264,7 +268,10 @@ async function checkAllowDockerPlatformHandling(
 	const checkHasPlatformInfo = async (repository: string) => {
 		try {
 			const manifest = await getManifest(docker.modem, repository);
-			return manifest.Descriptor.mediaType === MEDIATYPE_MANIFEST_LIST_V2;
+			return [
+				MEDIATYPE_MANIFEST_LIST_V2,
+				MEDIATYPE_OCI_IMAGE_INDEX_V1,
+			].includes(manifest.Descriptor.mediaType);
 		} catch {
 			// eat the exception... yummy!
 		}

--- a/lib/multibuild/manifests.ts
+++ b/lib/multibuild/manifests.ts
@@ -24,6 +24,8 @@ export const MEDIATYPE_MANIFEST_V2 =
 	'application/vnd.docker.distribution.manifest.v2+json';
 export const MEDIATYPE_MANIFEST_LIST_V2 =
 	'application/vnd.docker.distribution.manifest.list.v2+json';
+export const MEDIATYPE_OCI_IMAGE_INDEX_V1 =
+	'application/vnd.oci.image.index.v1+json';
 
 export type DockerImageManifestPlatform = {
 	architecture?: string;

--- a/test/multibuild/manifests.spec.ts
+++ b/test/multibuild/manifests.spec.ts
@@ -19,6 +19,7 @@ import {
 	MEDIATYPE_MANIFEST_V1,
 	MEDIATYPE_MANIFEST_LIST_V2,
 	MEDIATYPE_MANIFEST_V2,
+	MEDIATYPE_OCI_IMAGE_INDEX_V1,
 	getManifest,
 	DockerImageManifest,
 	DockerImageManifestPlatform,
@@ -44,6 +45,7 @@ class Tester {
 				MEDIATYPE_MANIFEST_V1,
 				MEDIATYPE_MANIFEST_LIST_V2,
 				MEDIATYPE_MANIFEST_V2,
+				MEDIATYPE_OCI_IMAGE_INDEX_V1,
 			]);
 			expect(manifest.Descriptor.digest).to.not.be.undefined;
 			expect(manifest.Platforms).to.not.be.undefined;
@@ -76,6 +78,14 @@ describe('docker.io', () => {
 
 describe('grc.io', () => {
 	const tester = new Tester('gcr.io/google_containers/pause:latest');
+
+	describe('getManifest', () => {
+		tester.testGetManifest();
+	});
+});
+
+describe('OCI Image Index', () => {
+	const tester = new Tester('docker.io/moby/buildkit:latest');
 
 	describe('getManifest', () => {
 		tester.testGetManifest();


### PR DESCRIPTION
Similar to Manifest v2, OCI Image Index manifest types support the platform arg, and if the default host
platform is not avilable in the manfiest they will actually fail to pull.

Resolves: https://github.com/balena-io-modules/balena-compose/issues/23