### PR TITLE
Use registry credentials to query image manifest

### DIFF
--- a/lib/multibuild/build.ts
+++ b/lib/multibuild/build.ts
@@ -303,7 +303,7 @@ async function checkAllowDockerPlatformHandling(
 	await Promise.all(
 		imageReferences.map(async (r) => {
 			try {
-				const manifest = await getManifest(docker.modem, r);
+				const manifest = await getManifest(docker.modem, r, task.dockerOpts);
 				const hasPlatformSupport = [
 					MEDIATYPE_MANIFEST_LIST_V2,
 					MEDIATYPE_OCI_IMAGE_INDEX_V1,

--- a/lib/multibuild/external.ts
+++ b/lib/multibuild/external.ts
@@ -54,13 +54,13 @@ export function pullExternal(
 	}
 
 	const opts = task.dockerOpts || {};
-	let authConfigPromise: Promise<RegistrySecret | {}> | {} = {};
+	let authConfigObj: RegistrySecret | {} = {};
 	if (opts.registryconfig) {
-		authConfigPromise = getAuthConfigObj(imageName, opts.registryconfig);
+		authConfigObj = getAuthConfigObj(imageName, opts.registryconfig);
 	}
 
 	const startTime = Date.now();
-	return Bluebird.resolve(authConfigPromise)
+	return Bluebird.resolve(authConfigObj)
 		.then((authConfig: RegistrySecret | {}) => {
 			if (authConfig && Object.keys(authConfig).length > 0) {
 				opts.authconfig = authConfig;

--- a/lib/multibuild/registry-secrets.ts
+++ b/lib/multibuild/registry-secrets.ts
@@ -23,6 +23,7 @@
 
 import * as ajv from 'ajv';
 
+import { getRegistryAndName } from './utils';
 import { RegistrySecretValidationError } from './errors';
 export { RegistrySecretValidationError } from './errors';
 
@@ -154,11 +155,10 @@ export function addCanonicalDockerHubEntry(registryconfig: RegistrySecrets) {
  * `addCanonicalDockerHubEntry(registryconfig)` as needed. The builders do
  * this in `resin-builder/src/metadata.ts`.
  */
-export async function getAuthConfigObj(
+export function getAuthConfigObj(
 	imageName: string,
 	registryconfig: RegistrySecrets,
-): Promise<RegistrySecrets | {}> {
-	const { getRegistryAndName } = await import('./utils');
+): RegistrySecrets | {} {
 	const { registry } = getRegistryAndName(imageName);
 	// If the imageName was prefixed by a domain name or IP address,
 	// use it to query the registryconfig and return.


### PR DESCRIPTION
DockerHub rate limits for unauthenticated users are much smaller than even for free authenticated users. This can cause false negatives when querying the manifest if the host is being rate limited. Using the docker registry credentials when querying the manifest solves this.

Change-type: minor