### PR TITLE
Optimize docker requests for local builds

### DIFF
--- a/lib/multibuild/external.ts
+++ b/lib/multibuild/external.ts
@@ -62,7 +62,10 @@ export async function pullExternal(
 		if (authConfig && Object.keys(authConfig).length > 0) {
 			opts.authconfig = authConfig;
 		}
-		await dockerProgress.pull(imageName, progressHook, opts);
+
+		// Remove cachefrom from pull options as it is not needed
+		const { cachefrom, ...pullOpts } = opts;
+		await dockerProgress.pull(imageName, progressHook, pullOpts);
 		const image = new LocalImage(docker, imageName, task.serviceName, {
 			external: true,
 			successful: true,


### PR DESCRIPTION
This PR adds some optimizations for requests going over the docker socket during local builds. 

- It adds a filter to avoid querying the registry for the manifest of images created during intermediate build stages. 
- It removes `cachefrom` from the options passed to the `pull` operation, as there is evidence to suggest that the cache option getting too big would be the cause of builds terminating without error on balena-io/balena-cli#2165. The `cachefrom` option is not used by Docker's [ImageCreate](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageCreate) endpoint, so removing should have no side effects.

Change-type: patch