### PR TITLE
api: Restore the accidentally removed concurrency limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "klaw": "^4.0.1",
     "lodash": "^4.17.19",
     "mz": "^2.7.0",
+    "p-map": "^4.0.0",
     "pinejs-client-request": "^7.3.5",
     "request": "^2.88.2",
     "semver": "^7.3.5",


### PR DESCRIPTION
Depends-on: https://github.com/balena-io-modules/balena-compose/pull/36
Change-type: patch
See: https://github.com/balena-io-modules/balena-compose/pull/32/files#diff-1b4d40e2938c5e5f9c316bc5dca572406d9285437650669024f871882a053cd2
See: https://balena.zulipchat.com/#narrow/stream/403752-channel.2Fsupport-help/topic/balena.20deploy.20too.20many.20requests