### PR TITLE
Fix disposing the docker daemon request on non-network errors

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,7 +1,4 @@
 module.exports = {
   timeout: 25000,
   spec: 'test/**/*.spec.ts',
-  // TODO: This shouldn't be necessary, but the tests on node20 hang, while they pass on node 16 & 18.
-  // `leaked-handles` showed an unclosed docker deamon connection.
-  exit: true,
 };


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io-modules/resin-docker-build/pull/31