### PR TITLE
Upgrade dockerode to v4.0.2

### DIFF
--- a/lib/build/builder.ts
+++ b/lib/build/builder.ts
@@ -26,7 +26,7 @@ import * as stream from 'node:stream';
 import * as tar from 'tar-stream';
 
 // Import hook definitions
-import * as Plugin from './plugin';
+import type * as Plugin from './plugin';
 import * as Utils from './utils';
 
 export type ErrorHandler = (error: Error) => void;

--- a/lib/build/utils.ts
+++ b/lib/build/utils.ts
@@ -16,7 +16,7 @@
  */
 import * as klaw from 'klaw';
 
-import * as Plugin from './plugin';
+import type * as Plugin from './plugin';
 
 /**
  * Given a docker 'arrow message' containing a sha representing

--- a/lib/dockerfile/index.ts
+++ b/lib/dockerfile/index.ts
@@ -33,7 +33,7 @@ export function process(
 			return line[0] !== '#'
 				? lodash.template(line, { interpolate: /%%([A-Z][A-Z_]+)%%/ })(
 						variables,
-				  )
+					)
 				: line;
 		})
 		.join('\n');

--- a/lib/multibuild/build-metadata.ts
+++ b/lib/multibuild/build-metadata.ts
@@ -15,17 +15,19 @@
  * limitations under the License.
  */
 
-import { Either, isLeft } from 'fp-ts/lib/Either';
-import * as t from 'io-ts';
+import type { Either } from 'fp-ts/lib/Either';
+import { isLeft } from 'fp-ts/lib/Either';
+import type * as t from 'io-ts';
 import { reporter } from 'io-ts-reporters';
 import * as jsYaml from 'js-yaml';
 import * as _ from 'lodash';
 import * as Path from 'path';
 import type * as Stream from 'stream';
-import * as tar from 'tar-stream';
+import type * as tar from 'tar-stream';
 import * as TarUtils from 'tar-utils';
 
-import { BalenaYml, parsedBalenaYml, ParsedBalenaYml } from './build-secrets';
+import type { BalenaYml, ParsedBalenaYml } from './build-secrets';
+import { parsedBalenaYml } from './build-secrets';
 import {
 	BalenaYMLValidationError,
 	MultipleBalenaConfigFilesError,
@@ -33,9 +35,9 @@ import {
 	RegistrySecretValidationError,
 } from './errors';
 import * as PathUtils from './path-utils';
+import type { RegistrySecrets } from './registry-secrets';
 import {
 	addCanonicalDockerHubEntry,
-	RegistrySecrets,
 	RegistrySecretValidator,
 } from './registry-secrets';
 

--- a/lib/multibuild/build-secrets/index.ts
+++ b/lib/multibuild/build-secrets/index.ts
@@ -27,7 +27,8 @@ import * as dockerfileTemplate from '../../dockerfile';
 
 import type BuildMetadata from '../build-metadata';
 import { BuildSecretMissingError, SecretPopulationError } from '../errors';
-import { PermissiveVarList, VarList } from '../validation-types/varlist';
+import type { VarList } from '../validation-types/varlist';
+import { PermissiveVarList } from '../validation-types/varlist';
 import { pipeline } from 'stream';
 
 export const secretType = t.interface({

--- a/lib/multibuild/build.ts
+++ b/lib/multibuild/build.ts
@@ -20,7 +20,8 @@ import * as _ from 'lodash';
 import * as semver from 'semver';
 import * as stream from 'stream';
 
-import { Builder, BuildHooks, FromTagInfo } from '../build';
+import type { BuildHooks, FromTagInfo } from '../build';
+import { Builder } from '../build';
 
 import type { SecretsPopulationMap } from './build-secrets';
 import type { BuildTask } from './build-task';

--- a/lib/multibuild/index.ts
+++ b/lib/multibuild/index.ts
@@ -26,13 +26,13 @@ import * as Compose from '../parse';
 
 import { runBuildTask } from './build';
 import BuildMetadata from './build-metadata';
+import type { SecretsPopulationMap } from './build-secrets';
 import {
 	BalenaYml,
 	generateSecretPopulationMap,
 	ParsedBalenaYml,
 	populateSecrets,
 	removeSecrets,
-	SecretsPopulationMap,
 } from './build-secrets';
 import type { BuildTask } from './build-task';
 import * as contracts from './contracts';

--- a/lib/parse/compose.ts
+++ b/lib/parse/compose.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 import * as _ from 'lodash';
 import * as path from 'path';
 
@@ -13,7 +13,7 @@ import {
 	SchemaVersion,
 	validate,
 } from './schemas';
-import {
+import type {
 	BuildConfig,
 	Composition,
 	Dict,

--- a/lib/release/api.ts
+++ b/lib/release/api.ts
@@ -2,9 +2,9 @@ import pMap = require('p-map');
 import type { PinejsClientCore, RetryParameters } from 'pinejs-client-core';
 import { PinejsClientRequest } from 'pinejs-client-request';
 import * as models from './models';
-import { Dict } from './types';
+import type { Dict } from './types';
 
-import { Composition } from '../../lib/parse';
+import type { Composition } from '../../lib/parse';
 
 const MAX_CONCURRENT_REQUESTS = 5;
 

--- a/lib/resolve/index.ts
+++ b/lib/resolve/index.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 import * as _ from 'lodash';
-import { Readable, pipeline } from 'stream';
+import type { Readable } from 'stream';
+import { pipeline } from 'stream';
 import * as tar from 'tar-stream';
 import * as TarUtils from 'tar-utils';
 

--- a/lib/resolve/resolver.ts
+++ b/lib/resolve/resolver.ts
@@ -1,6 +1,6 @@
 import Bundle from './bundle';
 import { FileInfo } from './fileInfo';
-import { ParsedPathPlus } from './utils';
+import type { ParsedPathPlus } from './utils';
 
 // Make the external types available to implementers
 export { Bundle, FileInfo };

--- a/lib/resolve/resolvers/archDockerfile.ts
+++ b/lib/resolve/resolvers/archDockerfile.ts
@@ -18,8 +18,9 @@ import { posix } from 'path';
 
 import * as DockerfileTemplate from '../../dockerfile';
 
-import { Bundle, FileInfo, Resolver } from '../resolver';
-import { ParsedPathPlus, removeExtension } from '../utils';
+import type { Bundle, FileInfo, Resolver } from '../resolver';
+import type { ParsedPathPlus } from '../utils';
+import { removeExtension } from '../utils';
 import { DockerfileTemplateVariableError } from './dockerfileTemplate';
 
 // Internal tuple to pass files and their extensions around

--- a/lib/resolve/resolvers/dockerfile.ts
+++ b/lib/resolve/resolvers/dockerfile.ts
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Bundle } from '../resolver';
+import type { Bundle } from '../resolver';
 
-import { FileInfo, Resolver } from '../resolver';
-import { ParsedPathPlus } from '../utils';
+import type { FileInfo, Resolver } from '../resolver';
+import type { ParsedPathPlus } from '../utils';
 
 export class DockerfileResolver implements Resolver {
 	public priority = 0;

--- a/lib/resolve/resolvers/dockerfileTemplate.ts
+++ b/lib/resolve/resolvers/dockerfileTemplate.ts
@@ -17,8 +17,9 @@
 import { TypedError } from 'typed-error';
 
 import * as DockerfileTemplate from '../../dockerfile';
-import { Bundle, FileInfo, Resolver } from '../resolver';
-import { ParsedPathPlus, removeExtension } from '../utils';
+import type { Bundle, FileInfo, Resolver } from '../resolver';
+import type { ParsedPathPlus } from '../utils';
+import { removeExtension } from '../utils';
 
 export class DockerfileTemplateVariableError extends TypedError {}
 

--- a/lib/resolve/resolvers/nodeResolver.ts
+++ b/lib/resolve/resolvers/nodeResolver.ts
@@ -23,8 +23,8 @@ import { promisify } from 'util';
 
 const getAsync = promisify(request.get);
 
-import { Bundle, FileInfo, Resolver } from '../resolver';
-import { ParsedPathPlus } from '../utils';
+import type { Bundle, FileInfo, Resolver } from '../resolver';
+import type { ParsedPathPlus } from '../utils';
 
 const versionTest = RegExp.prototype.test.bind(/^[0-9]+\.[0-9]+\.[0-9]+$/);
 const getDeviceTypeVersions = memoize(

--- a/lib/resolve/utils.ts
+++ b/lib/resolve/utils.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { ParsedPath, posix } from 'path';
+import type { ParsedPath } from 'path';
+import { posix } from 'path';
 
 export interface ParsedPathPlus extends ParsedPath {
 	minusExt: string;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@balena/lint": "^7.2.1",
     "@types/chai-as-promised": "^7.1.3",
-    "@types/docker-modem": "^3.0.1",
+    "@types/docker-modem": "^3.0.6",
     "@types/dockerode": "^3.3.23",
     "@types/duplexify": "^3.6.1",
     "@types/event-stream": "^4.0.0",
@@ -66,10 +66,10 @@
   "dependencies": {
     "ajv": "^6.12.3",
     "docker-file-parser": "^1.0.7",
-    "docker-modem": "^3.0.3",
+    "docker-modem": "^5.0.3",
     "docker-progress": "^5.1.0",
     "dockerfile-ast": "^0.2.1",
-    "dockerode": "^3.3.5",
+    "dockerode": "^4.0.2",
     "duplexify": "^4.1.2",
     "event-stream": "^4.0.1",
     "fp-ts": "^2.8.1",

--- a/test/build/all.spec.ts
+++ b/test/build/all.spec.ts
@@ -23,7 +23,8 @@ import * as url from 'url';
 
 import * as proxyquire from 'proxyquire';
 
-import { Builder, BuildHooks } from '../../lib/build';
+import type { BuildHooks } from '../../lib/build';
+import { Builder } from '../../lib/build';
 import * as Utils from '../../lib/build/utils';
 
 const TEST_FILE_PATH = 'test/build/test-files';

--- a/test/build/build_stream.spec.ts
+++ b/test/build/build_stream.spec.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 import { assert } from 'chai';
-import { Readable, Stream, Writable } from 'stream';
+import type { Readable, Writable } from 'stream';
+import { Stream } from 'stream';
 
 import * as proxyquire from 'proxyquire';
 

--- a/test/multibuild/build-utils.ts
+++ b/test/multibuild/build-utils.ts
@@ -18,12 +18,12 @@
 import * as Dockerode from 'dockerode';
 import * as fs from 'fs';
 import * as Path from 'path';
-import * as Stream from 'stream';
-import * as tar from 'tar-stream';
+import type * as Stream from 'stream';
+import type * as tar from 'tar-stream';
 import * as Url from 'url';
 
 import BuildMetadata from '../../lib/multibuild/build-metadata';
-import { BalenaYml } from '../../lib/multibuild/build-secrets';
+import type { BalenaYml } from '../../lib/multibuild/build-secrets';
 
 export const TEST_FILES_PATH = 'test/multibuild/test-files';
 

--- a/test/multibuild/build.spec.ts
+++ b/test/multibuild/build.spec.ts
@@ -30,12 +30,8 @@ import {
 
 import * as Compose from '../../lib/parse';
 
-import {
-	splitBuildStream,
-	BuildTask,
-	BuildProcessError,
-	LocalImage,
-} from '../../lib/multibuild';
+import type { BuildTask, LocalImage } from '../../lib/multibuild';
+import { splitBuildStream, BuildProcessError } from '../../lib/multibuild';
 import { runBuildTask } from '../../lib/multibuild/build';
 import { resolveTask } from '../../lib/multibuild/resolve';
 

--- a/test/multibuild/manifests.spec.ts
+++ b/test/multibuild/manifests.spec.ts
@@ -15,14 +15,16 @@
  * limitations under the License.
  */
 
+import type {
+	DockerImageManifest,
+	DockerImageManifestPlatform,
+} from '../../lib/multibuild/manifests';
 import {
 	MEDIATYPE_MANIFEST_V1,
 	MEDIATYPE_MANIFEST_LIST_V2,
 	MEDIATYPE_MANIFEST_V2,
 	MEDIATYPE_OCI_IMAGE_INDEX_V1,
 	getManifest,
-	DockerImageManifest,
-	DockerImageManifestPlatform,
 } from '../../lib/multibuild/manifests';
 import { expect } from 'chai';
 import * as Dockermodem from 'docker-modem';

--- a/test/multibuild/multibuild.spec.ts
+++ b/test/multibuild/multibuild.spec.ts
@@ -18,7 +18,7 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'fs';
-import * as Stream from 'stream';
+import type * as Stream from 'stream';
 
 import {
 	checkExists,
@@ -27,7 +27,8 @@ import {
 	TEST_FILES_PATH,
 } from './build-utils';
 
-import { performBuilds, BuildTask, LocalImage } from '../../lib/multibuild';
+import type { BuildTask, LocalImage } from '../../lib/multibuild';
+import { performBuilds } from '../../lib/multibuild';
 import BuildMetadata from '../../lib/multibuild/build-metadata';
 
 chai.use(chaiAsPromised);

--- a/test/multibuild/registry-secrets.spec.ts
+++ b/test/multibuild/registry-secrets.spec.ts
@@ -23,9 +23,9 @@ import * as fs from 'fs';
 
 import { normalize } from '../../lib/parse';
 
+import type { RegistrySecrets } from '../../lib/multibuild';
 import {
 	addCanonicalDockerHubEntry,
-	RegistrySecrets,
 	RegistrySecretValidator,
 	RegistrySecretValidationError,
 	splitBuildStream,

--- a/test/multibuild/resolve.spec.ts
+++ b/test/multibuild/resolve.spec.ts
@@ -1,10 +1,10 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'fs';
-import { Pack } from 'tar-stream';
+import type { Pack } from 'tar-stream';
 
 import BuildMetadata from '../../lib/multibuild/build-metadata';
-import { BuildTask } from '../../lib/multibuild';
+import type { BuildTask } from '../../lib/multibuild';
 import { resolveTask } from '../../lib/multibuild/resolve';
 
 import { TEST_FILES_PATH } from './build-utils';

--- a/test/multibuild/stream.spec.ts
+++ b/test/multibuild/stream.spec.ts
@@ -18,7 +18,7 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'fs';
 import * as _ from 'lodash';
-import * as Stream from 'stream';
+import type * as Stream from 'stream';
 import * as tar from 'tar-stream';
 
 import * as Compose from '../../lib/parse';

--- a/test/resolve/all.spec.ts
+++ b/test/resolve/all.spec.ts
@@ -17,7 +17,7 @@
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'fs';
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 import * as tar from 'tar-stream';
 import * as TarUtils from 'tar-utils';
 

--- a/typings/event-stream.d.ts
+++ b/typings/event-stream.d.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Stream } from 'stream';
+import type { Stream } from 'stream';
 
 /**
  * Additional typing information that is merged with that available in the npm


### PR DESCRIPTION
Upgrade dockerode to v4. This upgrade gets the code past the issue raised in #15, although that problem was solved earlier by eliminating use of Bluebird in #40 and #44. We want to stay current with dockerode.

Also includes updates from prettier. This PR is designed to work with bug fix #47, which also includes those updates from prettier.
