### PR TITLE
Update `contract` types for API v7

### DIFF
--- a/lib/release/api.ts
+++ b/lib/release/api.ts
@@ -10,13 +10,13 @@ const MAX_CONCURRENT_REQUESTS = 5;
 export interface Request {
 	/**
 	 * An instance of PineJS, appropriately authenticated and configured for the
-	 * API server to use. The compatible API versions are v5 and v6, so make sure to
+	 * API server to use. The only compatible API version is v7, so make sure to
 	 * configure `apiPrefix` appropriately.
 	 *
 	 * ```
 	 * import Pine from 'pinejs-client-fetch';
 	 * const client = new Pine({
-	 *   apiPrefix: 'https://api.balena-cloud.com/v6',
+	 *   apiPrefix: 'https://api.balena-cloud.com/v7',
 	 *   passthrough: {
 	 *     headers: {
 	 *       Authorization: `Bearer ${authToken}`,

--- a/lib/release/api.ts
+++ b/lib/release/api.ts
@@ -67,8 +67,8 @@ export interface Request {
 	 */
 	semver?: string;
 
-	/** 'balena.yml' contract contents (stringified JSON) */
-	contract?: string;
+	/** 'balena.yml' contract contents */
+	contract?: models.JsonType;
 }
 
 export interface Response {
@@ -79,7 +79,7 @@ export interface Response {
 /**
  * This is the entry point for deploying a docker-compose.yml to devices.
  */
-export async function create(req: Request): Promise<Response> {
+export async function create(req: Request) {
 	const api = req.client;
 
 	// Ensure that the user and app exist and the user has access to them.
@@ -222,7 +222,7 @@ async function getOrCreateService(
 async function createRelease(
 	api: PinejsClientCore<unknown>,
 	body: models.ReleaseAttributes,
-): Promise<models.ReleaseModel> {
+) {
 	return (await api
 		.post({
 			resource: 'release',

--- a/lib/release/models.ts
+++ b/lib/release/models.ts
@@ -4,6 +4,12 @@ import * as errors from './errors';
 
 // These interfaces declare all model attributes except relations.
 
+interface AnyObject {
+	[index: string]: any;
+}
+
+export type JsonType = AnyObject;
+
 interface ServiceAttributesBase {
 	service_name: string;
 }
@@ -15,7 +21,7 @@ interface ReleaseAttributesBase {
 	source: string;
 	start_timestamp: Date;
 	end_timestamp?: Date;
-	contract?: string;
+	contract?: JsonType;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/lib/release/models.ts
+++ b/lib/release/models.ts
@@ -33,7 +33,7 @@ interface ImageAttributesBase {
 	start_timestamp: Date;
 	end_timestamp?: Date;
 	dockerfile?: string;
-	image_size?: number;
+	image_size?: string;
 	project_type?: string;
 	error_message?: string;
 	build_log?: string;


### PR DESCRIPTION
Update `contract` types for API v7

Change-type: patch
See: https://balena.fibery.io/Work/Task/Update-the-balena-cli-to-use-the-v7-model-2205