### PR TITLE
Make pinejs-client-core a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "common-tags": "^1.8.2",
     "mocha": "^10.2.0",
     "ncp": "^2.0.0",
+    "pinejs-client-core": "^7.2.0",
     "proxyquire": "^2.1.3",
     "rimraf": "^5.0.1",
     "ts-mocha": "^10.0.0",
@@ -82,12 +83,14 @@
     "memoizee": "^0.4.15",
     "mz": "^2.7.0",
     "p-map": "^4.0.0",
-    "pinejs-client-core": "^6.14.13",
     "semver": "^7.3.5",
     "stream-to-promise": "^3.0.0",
     "tar-stream": "^3.1.6",
     "tar-utils": "^3.0.2",
     "typed-error": "^3.2.1"
+  },
+  "peerDependencies": {
+    "pinejs-client-core": "^6.14.13 || ^7.0.0"
   },
   "versionist": {
     "publishedAt": "2024-09-17T15:05:46.783Z"


### PR DESCRIPTION
Make pinejs-client-core a peer dependency

Change-type: major