### PR TITLE
Ensure docker opts labels are always defined

### DIFF
--- a/lib/multibuild/build.ts
+++ b/lib/multibuild/build.ts
@@ -102,7 +102,7 @@ const generateBuildArgs = (
 
 const generateLabels = (task: BuildTask): { labels?: Dictionary<string> } => {
 	return {
-		labels: task.labels,
+		labels: { ...task.labels },
 	};
 };
 


### PR DESCRIPTION
The `generateLabels` can create docker optiosn with a `labels: undefined` property.

This may cause issues with some docker runtimes, resulting in the response

```
(HTTP code 400) unexpected - failed to parse query parameter 'labels': "": unexpected end of JSON input
```

Change-type: patch