### PR TITLE
JSON stringify cachefrom option for builds

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, closed]
     branches:
-      - "main"
-      - "master"
+      - 'main'
+      - 'master'
   pull_request_target:
     types: [opened, synchronize, closed]
     branches:
-      - "main"
-      - "master"
+      - 'main'
+      - 'master'
 
 jobs:
   flowzone:
@@ -26,3 +26,8 @@ jobs:
         github.event_name == 'pull_request_target'
       )
     secrets: inherit
+    with:
+      runs_on: >
+        [
+          "self-hosted", "X64"
+        ]

--- a/lib/multibuild/utils.ts
+++ b/lib/multibuild/utils.ts
@@ -78,7 +78,9 @@ export function generateBuildTasks(
 				// translating to dockerode ImageBuildOptions properties
 				{
 					dockerOpts: {
-						...(cachefrom ? { cachefrom } : {}),
+						// TODO: JSON serialization should no longer be necessary
+						// if https://github.com/apocas/dockerode/pull/793 is merged
+						...(cachefrom ? { cachefrom: JSON.stringify(cachefrom) } : {}),
 						...(shmsize ? { shmsize } : {}),
 						...(target ? { target } : {}),
 						...(extrahosts ? { extrahosts } : {}),

--- a/test/multibuild/build.spec.ts
+++ b/test/multibuild/build.spec.ts
@@ -693,7 +693,7 @@ describe('Specifying build options', async () => {
 			expect(newTask)
 				.to.have.property('dockerOpts')
 				.that.has.property('cachefrom')
-				.that.deep.equals(['alpine:latest']);
+				.that.deep.equals(JSON.stringify(['alpine:latest']));
 
 			expect(image).to.not.have.property('error');
 		});


### PR DESCRIPTION
A change the way options are serialized in docker-modem causes an issue with builds using the `cachefrom` option and library tests to fail. This change can be reverted if apocas/dockerode#793 is merged.

Change-type: patch
Relates-to: apocas/docker-modem#181
Relates-to: apocas/dockerode#792