### PR TITLE
Add slug to contracts from requirement labels

### DIFF
--- a/lib/parse/compose.ts
+++ b/lib/parse/compose.ts
@@ -604,6 +604,7 @@ export function parse(c: Composition): ImageDescriptor[] {
 }
 
 function createContractFromLabels(
+	serviceName: string,
 	labels?: Dict<string>,
 ): ContractObject | null {
 	const requires = Object.entries(labels ?? {}).flatMap(([key, value]) => {
@@ -626,6 +627,7 @@ function createContractFromLabels(
 
 	return {
 		type: 'sw.container',
+		slug: `contract-for-${serviceName}`,
 		requires,
 	};
 }
@@ -634,7 +636,7 @@ function createImageDescriptor(
 	serviceName: string,
 	service: Service,
 ): ImageDescriptor {
-	const contract = createContractFromLabels(service.labels);
+	const contract = createContractFromLabels(serviceName, service.labels);
 	if (service.image && !service.build) {
 		return {
 			serviceName,

--- a/test/multibuild/contracts.spec.ts
+++ b/test/multibuild/contracts.spec.ts
@@ -144,6 +144,7 @@ describe('Container contracts', () => {
 			.to.have.property('contract')
 			.that.deep.equals({
 				type: 'sw.container',
+				slug: 'contract-for-one',
 				requires: [
 					{
 						type: 'hw.device-type',
@@ -156,6 +157,7 @@ describe('Container contracts', () => {
 			.to.have.property('contract')
 			.that.deep.equals({
 				type: 'sw.container',
+				slug: 'contract-for-two',
 				requires: [
 					{
 						type: 'sw.supervisor',
@@ -207,6 +209,7 @@ describe('Container contracts', () => {
 			.to.have.property('contract')
 			.that.deep.equals({
 				type: 'sw.container',
+				slug: 'contract-for-other',
 				requires: [
 					{
 						type: 'hw.device-type',


### PR DESCRIPTION
This ensures that the supervisor accepts contracts generated when using the label. See
https://github.com/balena-os/balena-supervisor/blob/master/src/lib/contracts.ts#L194-L206 for the validation object.

Change-type: patch