### PR TITLE
Forward errors with extract stream to the `next` handler

### DIFF
--- a/lib/multibuild/index.ts
+++ b/lib/multibuild/index.ts
@@ -129,11 +129,10 @@ export async function fromImageDescriptors(
 				}
 				next();
 			} catch (e) {
-				if (e instanceof ContractError) {
-					reject(e);
-					return;
-				}
-				reject(new TarError(e));
+				const err = e instanceof ContractError ? e : new TarError(e);
+				reject(err);
+				// Also make sure the stream errors/finishes draining/frees memory
+				next(err);
 			}
 		});
 		extract.on('finish', () => {


### PR DESCRIPTION
This ensures the stream knows what's happened and can do any necessary
cleanup/handling/freeing of resources

Change-type: patch
