### PR TITLE
Make use of `throughTarStream` to avoid buffering memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "semver": "^7.7.2",
     "stream-to-promise": "^3.0.0",
     "tar-stream": "^3.1.7",
-    "tar-utils": "^3.0.3",
+    "tar-utils": "^3.1.0",
     "typed-error": "^3.2.2"
   },
   "peerDependencies": {

--- a/repo.yml
+++ b/repo.yml
@@ -1,1 +1,4 @@
 type: 'node'
+upstream:
+  - repo: 'tar-utils'
+    url: 'https://github.com/balena-io-modules/node-tar-utils'

--- a/test/multibuild/multibuild.spec.ts
+++ b/test/multibuild/multibuild.spec.ts
@@ -45,7 +45,7 @@ describe('performBuilds()', () => {
 		const outParser = new StreamOutputParser();
 		const tarFilename = `${TEST_FILES_PATH}/build-secrets-1.tar`;
 		const buildMetadata = new BuildMetadata(['.balena', '.resin']);
-		await buildMetadata.extractMetadata(fs.createReadStream(tarFilename));
+		buildMetadata.extractMetadata(fs.createReadStream(tarFilename)).resume();
 
 		const task: BuildTask = {
 			buildMetadata,


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Builder-API-pods-frequent-OOM-ECONNRESET-reset-on-push-143