### PR TITLE
Allow generating tasks and their build streams separately

### DIFF
--- a/lib/multibuild/build-task.ts
+++ b/lib/multibuild/build-task.ts
@@ -16,7 +16,6 @@
  */
 import type { ProgressCallback } from 'docker-progress';
 import type * as Stream from 'stream';
-import type * as tar from 'tar-stream';
 import type BuildMetadata from './build-metadata';
 
 /**
@@ -80,7 +79,7 @@ export interface BuildTask {
 	 *
 	 * If this task is an external image pull, this field will be null.
 	 */
-	buildStream?: tar.Pack;
+	buildStream?: Stream.Readable;
 	/**
 	 * This function should be provided by the caller. It is a hook which will
 	 * be called with the docker build output.

--- a/lib/multibuild/index.ts
+++ b/lib/multibuild/index.ts
@@ -116,7 +116,7 @@ export async function populateTaskBuildStream(
 					const newHeader =
 						header.name !== relative ? { ...header, name: relative } : header;
 
-					task.buildStream!.entry(newHeader, buf);
+					(task.buildStream as tar.Pack).entry(newHeader, buf);
 				} else {
 					entryStream.resume();
 				}
@@ -127,7 +127,7 @@ export async function populateTaskBuildStream(
 			}
 		});
 		extract.on('finish', () => {
-			task.buildStream!.finalize();
+			(task.buildStream as tar.Pack).finalize();
 			resolve();
 		});
 		extract.on('error', (e) => {
@@ -216,7 +216,7 @@ export async function fromImageDescriptors(
 						const newHeader =
 							header.name !== relative ? { ...header, name: relative } : header;
 
-						task.buildStream!.entry(newHeader, buf);
+						(task.buildStream as tar.Pack).entry(newHeader, buf);
 					}
 				} else {
 					entryStream.resume();
@@ -230,7 +230,7 @@ export async function fromImageDescriptors(
 		extract.on('finish', () => {
 			for (const task of tasks) {
 				if (!task.external) {
-					task.buildStream!.finalize();
+					(task.buildStream as tar.Pack).finalize();
 				}
 			}
 			resolve(tasks);

--- a/lib/multibuild/resolve.ts
+++ b/lib/multibuild/resolve.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 import * as _ from 'lodash';
-import type * as Stream from 'stream';
 
 import * as Resolve from '../resolve';
 import { ResolveListeners } from '../resolve';
@@ -73,7 +72,7 @@ export function resolveTask(
 	};
 
 	const bundle = new Resolve.Bundle(
-		task.buildStream as Stream.Readable,
+		task.buildStream!,
 		deviceType,
 		architecture,
 		dockerfileHook,

--- a/lib/multibuild/utils.ts
+++ b/lib/multibuild/utils.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 import * as _ from 'lodash';
-import * as tar from 'tar-stream';
 
 import type { ImageDescriptor } from '../parse';
 
@@ -66,7 +65,6 @@ export function generateBuildTasks(
 				{
 					external: false,
 					serviceName: img.serviceName,
-					buildStream: tar.pack(),
 					resolved: false,
 					buildMetadata,
 				},

--- a/lib/resolve/bundle.ts
+++ b/lib/resolve/bundle.ts
@@ -1,9 +1,11 @@
+import type { Stream } from 'node:stream';
+
 const emptyHook = (): Promise<void> => {
 	return Promise.resolve();
 };
 
 export class Bundle {
-	public tarStream: NodeJS.ReadableStream;
+	public tarStream: Stream.Readable;
 
 	/**
 	 * deviceType: The slug of the device type that this bundle has been created
@@ -44,7 +46,7 @@ export class Bundle {
 	 *  The architecture that this resin bundle is currently targeting
 	 */
 	public constructor(
-		tarStream: NodeJS.ReadableStream,
+		tarStream: Stream.Readable,
 		deviceType: string,
 		architecture: string,
 		hook: Bundle['dockerfileHook'] = emptyHook,


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Project/Incident-Investigation-Builder-Push-Failures-1847