### PR TITLE
Set label values to stringified number

### DIFF
--- a/lib/parse/compose.ts
+++ b/lib/parse/compose.ts
@@ -297,7 +297,7 @@ function normalizeService(
 		}
 		if (labels.length > 0) {
 			service.labels = {
-				...labels.reduce((o, l) => ({ ...o, [l]: 1 }), {}),
+				...labels.reduce((o, l) => ({ ...o, [l]: '1' }), {}),
 				...service.labels,
 			};
 		}

--- a/test/parse/all.spec.ts
+++ b/test/parse/all.spec.ts
@@ -169,13 +169,13 @@ describe('normalization', () => {
 	it('should normalize well-known bind mounts to labels', (done) => {
 		expect(c.services.s4.volumes).to.deep.equal([]);
 		expect(c.services.s4.labels).to.deep.equal({
-			'io.balena.features.balena-socket': 1,
-			'io.balena.features.dbus': 1,
-			'io.balena.features.sysfs': 1,
-			'io.balena.features.procfs': 1,
-			'io.balena.features.kernel-modules': 1,
-			'io.balena.features.firmware': 1,
-			'io.balena.features.journal-logs': 1,
+			'io.balena.features.balena-socket': '1',
+			'io.balena.features.dbus': '1',
+			'io.balena.features.sysfs': '1',
+			'io.balena.features.procfs': '1',
+			'io.balena.features.kernel-modules': '1',
+			'io.balena.features.firmware': '1',
+			'io.balena.features.journal-logs': '1',
 		});
 		done();
 	});


### PR DESCRIPTION
ImageLabel.value needs to be a string and not a number. Currently our builder fails due to the API throwing a DB error due to the type mismatch.

Change-type: patch

---

See: https://balena.fibery.io/Work/Improvement/Fix-compose-volume-label-rewrite-3502
Related support ticket: https://balena.zendesk.com/agent/tickets/5697

Tested in:
- https://github.com/balena-io/balena-builder/pull/1440

---

Here is an example of the error the builder runs into with the following `docker-compose.yml` snippet including a `/sys` volume. After deploying a builder version that includes the updated `@balena/compose` package, pushing the same `docker-compose.yml` file succeeds.
```yaml
version: "2"

services:
  balena-hello-world:
    build: .
    volumes:
      - /sys:/sys:rw
    ports:
      - "127.0.0.1:80:80"
```
<img width="801" height="357" alt="builder-error" src="https://github.com/user-attachments/assets/d9d3c8d8-5f45-46cf-8f6e-469eb57d560b" />

In this example, the logic rewrites the `/sys` mount to a `io.balena.features.sysfs` label with a `1` (number) value. This value is then sent to the API to create an `image_label` resource with a numeric value when it needs to be a string value - hence the error returned by the API:
```
Upstream API server/DB error RequestError: "value" is not a string: 1
    at AuthenticatedApi._request (/usr/src/app/node_modules/pinejs-client-fetch/src/index.ts:63:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async AuthenticatedApi.callWithRetry (/usr/src/app/node_modules/pinejs-client-core/src/index.ts:1289:12)
    at async ImageLabel.post (/usr/src/app/src/api/image-label.ts:11:3) {
  statusCode: 400,
  responseHeaders: Headers {
    'x-frame-options': 'DENY',
    'x-content-type-options': 'nosniff',
    'access-control-allow-origin': '*',
    'access-control-allow-credentials': 'true',
    'access-control-expose-headers': 'Retry-After',
    'cache-control': 'no-cache',
    'content-type': 'application/json; charset=utf-8',
    'content-length': '30',
    etag: 'W/"1e-yLHJLw66bsWGh0TT65U9Axid0oM"',
    vary: 'Accept-Encoding',
    date: 'Thu, 01 Jan 2026 02:24:49 GMT',
    connection: 'keep-alive',
    'keep-alive': 'timeout=64'
  },
  code: 'PineClientFetchRequestError',
  status: 400
}
```