### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -12,6 +12,11 @@ on:
       - 'main'
       - 'master'
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -31,8 +31,3 @@ jobs:
         github.event_name == 'pull_request_target'
       )
     secrets: inherit
-    with:
-      runs_on: >
-        [
-          "self-hosted", "X64"
-        ]


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch