### PR TITLE
Bump @balena/compose-parser to 0.2.1

### DIFF
--- a/lib/multibuild/manifests.ts
+++ b/lib/multibuild/manifests.ts
@@ -73,7 +73,7 @@ export function getManifest(
 	return new Promise<DockerImageManifest>((resolve, reject) => {
 		modem.dial(optsf, (err: unknown, data: DockerImageManifest) => {
 			if (err) {
-				reject(err as Error);
+				reject(err instanceof Error ? err : new Error(String(err)));
 				return;
 			}
 			resolve(data);

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@balena/compose-parser": "^0.2.0",
+    "@balena/compose-parser": "^0.2.1",
     "ajv": "^6.12.6",
     "docker-file-parser": "^1.0.7",
     "docker-progress": "^5.3.1",

--- a/test/multibuild/resolve.spec.ts
+++ b/test/multibuild/resolve.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
-import type { Pack } from 'tar-stream';
 
 import BuildMetadata from '../../lib/multibuild/build-metadata';
 import type { BuildTask } from '../../lib/multibuild';
@@ -21,7 +20,7 @@ describe('Project resolution', () => {
 			resolved: false,
 			buildStream: fs.createReadStream(
 				`${TEST_FILES_PATH}/templateProject.tar`,
-			) as any as Pack,
+			),
 			serviceName: 'test',
 			buildMetadata,
 		};
@@ -51,9 +50,7 @@ describe('Project resolution', () => {
 			external: false,
 			resolved: false,
 			serviceName: 'test',
-			buildStream: fs.createReadStream(
-				`${TEST_FILES_PATH}/failedProject.tar`,
-			) as any as Pack,
+			buildStream: fs.createReadStream(`${TEST_FILES_PATH}/failedProject.tar`),
 			buildMetadata,
 		};
 
@@ -77,7 +74,7 @@ describe('Project resolution', () => {
 			resolved: false,
 			buildStream: fs.createReadStream(
 				`${TEST_FILES_PATH}/additional-template-vars.tar`,
-			) as any as Pack,
+			),
 			serviceName: 'test',
 			buildMetadata,
 		};
@@ -111,7 +108,7 @@ describe('Project resolution', () => {
 			resolved: false,
 			buildStream: fs.createReadStream(
 				`${TEST_FILES_PATH}/templateProject.tar`,
-			) as any as Pack,
+			),
 			serviceName: 'test',
 			buildMetadata,
 		};


### PR DESCRIPTION
This brings in the upstream container contract change from sw.compose to sw.spec.

Change-type: patch