### PR TITLE
Bump @balena/compose-parser to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@balena/compose-parser": "^0.2.1",
+    "@balena/compose-parser": "^0.2.4",
     "ajv": "^6.12.6",
     "docker-file-parser": "^1.0.7",
     "docker-progress": "^5.3.1",


### PR DESCRIPTION
This bump adds upstream patches to handle binary
paths with a space, and coerces null/undefined
env var values to empty string as the API does
not accept null/undefined env var values.

See: https://github.com/balena-io-modules/balena-compose-parser/pull/23
See: https://github.com/balena-io-modules/balena-compose-parser/pull/25
Change-type: patch