### PR TITLE
Bump @balena/compose-parser to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@balena/compose-parser": "^0.2.4",
+    "@balena/compose-parser": "^0.2.5",
     "ajv": "^6.12.6",
     "docker-file-parser": "^1.0.7",
     "docker-progress": "^5.3.1",


### PR DESCRIPTION
- Convert extra_hosts separator from `=` to `:`

Change-type: patch