### PR TITLE
Bump @balena/compose-parser to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@balena/compose-parser": "^0.2.4",
+    "@balena/compose-parser": "^0.2.5",
     "ajv": "^6.12.6",
     "docker-file-parser": "^1.0.7",
     "docker-progress": "^5.3.1",

--- a/test/parse/all.spec.ts
+++ b/test/parse/all.spec.ts
@@ -107,8 +107,8 @@ describe('normalization', () => {
 	});
 
 	it('should parse composition extra_hosts from objects or arrays', () => {
-		expect(c.services.s2.extra_hosts).to.deep.equal(['foo=127.0.0.1']);
-		expect(c.services.s3.extra_hosts).to.deep.equal(['bar=8.8.8.8']);
+		expect(c.services.s2.extra_hosts).to.deep.equal(['foo:127.0.0.1']);
+		expect(c.services.s3.extra_hosts).to.deep.equal(['bar:8.8.8.8']);
 	});
 
 	it('should parse composition networks and add on default network', () => {


### PR DESCRIPTION
- Convert extra_hosts separator from = to :
- Support apparmor=unconfined, seccomp=unconfined for security_opt

Change-type: patch