### PR TITLE
Switch from custom `Dictionary` type to built in `Record` typing

### DIFF
--- a/lib/multibuild/build-metadata.ts
+++ b/lib/multibuild/build-metadata.ts
@@ -49,7 +49,7 @@ enum MetadataFileType {
 
 export class BuildMetadata {
 	public registrySecrets: RegistrySecrets;
-	protected metadataFiles: Dictionary<Buffer> = {};
+	protected metadataFiles: Record<string, Buffer> = {};
 	protected balenaYml: BalenaYml;
 
 	public constructor(protected metadataDirectories: string[]) {}
@@ -157,8 +157,8 @@ export class BuildMetadata {
 		this.parseRegistrySecrets();
 	}
 
-	public getBuildVarsForService(serviceName: string): Dictionary<string> {
-		const vars: Dictionary<string> = {};
+	public getBuildVarsForService(serviceName: string): Record<string, string> {
+		const vars: Record<string, string> = {};
 		if (this.balenaYml.buildVariables.global != null) {
 			Object.assign(vars, this.balenaYml.buildVariables.global);
 		}

--- a/lib/multibuild/build-secrets/index.ts
+++ b/lib/multibuild/build-secrets/index.ts
@@ -52,21 +52,24 @@ export type SecretObject = t.TypeOf<typeof secretType>;
 export interface BalenaYml {
 	buildVariables: {
 		global?: VarList;
-		services?: Dictionary<VarList>;
+		services?: Record<string, VarList>;
 	};
 	buildSecrets: {
 		global?: SecretObject[];
-		services?: Dictionary<SecretObject[]>;
+		services?: Record<string, SecretObject[]>;
 	};
 }
 
 // We map the service name against the directory that the
 // secret files will be added to, and the secret files
 // themselves encoded in base64
-export type SecretsPopulationMap = Dictionary<{
-	tmpDirectory: string;
-	files: Dictionary<string>;
-}>;
+export type SecretsPopulationMap = Record<
+	string,
+	{
+		tmpDirectory: string;
+		files: Record<string, string>;
+	}
+>;
 
 export function generateSecretPopulationMap(
 	serviceNames: string[],

--- a/lib/multibuild/build-task.ts
+++ b/lib/multibuild/build-task.ts
@@ -45,12 +45,12 @@ export interface BuildTask {
 	 * If this is a Docker build task, this field will be set to the build
 	 * arguments which are to passed into the daemon
 	 */
-	args?: Dictionary<string>;
+	args?: Record<string, string>;
 	/**
 	 * If this is a Docker build task, this field will be set to the labels
 	 * which should be attached to the resulting image.
 	 */
-	labels?: Dictionary<string>;
+	labels?: Record<string, string>;
 	/**
 	 * If this value is set, the resulting image will be tagged as this
 	 * once built (or pulled).
@@ -136,7 +136,7 @@ export interface BuildTask {
 	/**
 	 * The container contract for this service
 	 */
-	contract?: Dictionary<unknown>;
+	contract?: Record<string, unknown>;
 
 	/**
 	 * Promise to ensure that build task is resolved before

--- a/lib/multibuild/build.ts
+++ b/lib/multibuild/build.ts
@@ -93,14 +93,16 @@ function taskHooks(
 
 const generateBuildArgs = (
 	task: BuildTask,
-	userArgs?: Dictionary<string>,
-): { buildargs?: Dictionary<string> } => {
+	userArgs?: Record<string, string>,
+): { buildargs?: Record<string, string> } => {
 	return {
 		buildargs: { ...task.args, ...userArgs },
 	};
 };
 
-const generateLabels = (task: BuildTask): { labels?: Dictionary<string> } => {
+const generateLabels = (
+	task: BuildTask,
+): { labels?: Record<string, string> } => {
 	return {
 		labels: task.labels,
 	};
@@ -119,7 +121,7 @@ export async function runBuildTask(
 	docker: Dockerode,
 	registrySecrets: RegistrySecrets,
 	secrets?: SecretsPopulationMap,
-	buildArgs?: Dictionary<string>,
+	buildArgs?: Record<string, string>,
 ): Promise<LocalImage> {
 	// Determine how we should handle the `platform` flag.
 	// This will be a combination of factors:

--- a/lib/multibuild/contracts.ts
+++ b/lib/multibuild/contracts.ts
@@ -26,14 +26,14 @@ export function isContractFile(filename: string): boolean {
 	return normalized === 'contract.yml' || normalized === 'contract.yaml';
 }
 
-export function processContract(buffer: Buffer): Dictionary<unknown> {
+export function processContract(buffer: Buffer): Record<string, unknown> {
 	const parsedBuffer = jsYaml.load(buffer.toString('utf8'));
 
 	if (parsedBuffer == null || typeof parsedBuffer !== 'object') {
 		throw new ContractValidationError('Container contract must be an object');
 	}
 
-	const contractObj = parsedBuffer as Dictionary<unknown>;
+	const contractObj = parsedBuffer as Record<string, unknown>;
 
 	if (contractObj.name == null) {
 		throw new ContractValidationError(

--- a/lib/multibuild/index.ts
+++ b/lib/multibuild/index.ts
@@ -192,7 +192,7 @@ export async function fromImageDescriptors(
 				if (matchingTasks.length > 0) {
 					// Add the file to every matching context
 					const buf = await TarUtils.streamToBuffer(entryStream);
-					let contract: Dictionary<unknown> | undefined;
+					let contract: Record<string, unknown> | undefined;
 					for (const task of matchingTasks) {
 						const relative = path.posix.relative(task.context!, header.name);
 
@@ -285,7 +285,7 @@ export function performResolution(
 	architecture: string,
 	deviceType: string,
 	resolveListeners: ResolveListeners,
-	additionalTemplateVars?: Dictionary<string>,
+	additionalTemplateVars?: Record<string, string>,
 	dockerfilePreprocessHook?: (dockerfile: string) => string,
 ): BuildTask[] {
 	return tasks.map((task) => {
@@ -306,7 +306,7 @@ export function performSingleResolution(
 	architecture: string,
 	deviceType: string,
 	resolveListeners: ResolveListeners,
-	additionalTemplateVars?: Dictionary<string>,
+	additionalTemplateVars?: Record<string, string>,
 	dockerfilePreprocessHook?: (dockerfile: string) => string,
 ): BuildTask {
 	task.architecture = architecture;
@@ -428,7 +428,7 @@ export async function performSingleBuild(
 	docker: Dockerode,
 	registrySecrets: RegistrySecrets,
 	secretMap?: SecretsPopulationMap,
-	buildArgs?: Dictionary<string>,
+	buildArgs?: Record<string, string>,
 ): Promise<LocalImage> {
 	try {
 		return await runBuildTask(

--- a/lib/multibuild/resolve.ts
+++ b/lib/multibuild/resolve.ts
@@ -41,7 +41,7 @@ export function resolveTask(
 	architecture: string,
 	deviceType: string,
 	resolveListeners: ResolveListeners,
-	additionalVars: Dictionary<string> = {},
+	additionalVars: Record<string, string> = {},
 	dockerfilePreprocessHook?: (content: string) => string,
 ): BuildTask {
 	// set the platform / architecture for pulling multiarch images

--- a/lib/multibuild/validation-types/varlist.ts
+++ b/lib/multibuild/validation-types/varlist.ts
@@ -29,7 +29,7 @@ const validate = (value: unknown): value is VarList => {
 	if (Array.isArray(value)) {
 		return validateStringArray(value);
 	} else if (value != null && typeof value === 'object') {
-		return Object.entries(value as Dictionary<unknown>).every(([k, v]) => {
+		return Object.entries(value as Record<string, unknown>).every(([k, v]) => {
 			return typeof v === 'string' && typeof k === 'string';
 		});
 	}

--- a/lib/release/api.ts
+++ b/lib/release/api.ts
@@ -68,7 +68,7 @@ export interface Request {
 	semver?: BalenaModel['release']['Write']['semver'];
 
 	/** 'balena.yml' contract contents */
-	contract?: Dictionary<any>;
+	contract?: Record<string, any>;
 
 	/**
 	 * List of image descriptors returned

--- a/lib/resolve/index.ts
+++ b/lib/resolve/index.ts
@@ -73,7 +73,7 @@ export function resolveInput(
 	resolvers: Resolver[],
 	resolveListeners: ResolveListeners,
 	dockerfile?: string,
-	additionalTemplateVars?: Dictionary<string>,
+	additionalTemplateVars?: Record<string, string>,
 ): tar.Pack {
 	if (dockerfile != null) {
 		// Ensure that this will match the entry in the tar archive
@@ -167,7 +167,7 @@ async function resolveTarStreamOnFinish(
 	resolvers: Resolver[],
 	pack: tar.Pack,
 	dockerfile?: string,
-	additionalTemplateVars?: Dictionary<string>,
+	additionalTemplateVars?: Record<string, string>,
 ): Promise<void> {
 	// Detect if any of the resolvers have been satisfied
 	const satisfied = _.orderBy(
@@ -210,7 +210,7 @@ async function addResolverOutput(
 	resolver: Resolver,
 	pack: tar.Pack,
 	specifiedDockerfilePath?: string,
-	additionalTemplateVars?: Dictionary<string>,
+	additionalTemplateVars?: Record<string, string>,
 ): Promise<void> {
 	// Now read the file, allow the resolver to process it, and return it
 	const dockerfile = await resolver.resolve(

--- a/lib/resolve/resolver.ts
+++ b/lib/resolve/resolver.ts
@@ -74,7 +74,7 @@ export interface Resolver {
 	resolve(
 		bundle: Bundle,
 		specifiedDockerfilePath?: string,
-		additionalTemplateVars?: Dictionary<string>,
+		additionalTemplateVars?: Record<string, string>,
 	): Promise<FileInfo>;
 
 	/**

--- a/lib/resolve/resolvers/archDockerfile.ts
+++ b/lib/resolve/resolvers/archDockerfile.ts
@@ -77,7 +77,7 @@ export class ArchDockerfileResolver implements Resolver {
 	public async resolve(
 		bundle: Bundle,
 		specifiedDockerfilePath?: string,
-		additionalTemplateVars: Dictionary<string> = {},
+		additionalTemplateVars: Record<string, string> = {},
 	) {
 		// Return the satisfied arch/deviceType specific dockerfile,
 		// as a plain Dockerfile, and the docker daemon will then

--- a/lib/resolve/resolvers/dockerfileTemplate.ts
+++ b/lib/resolve/resolvers/dockerfileTemplate.ts
@@ -71,7 +71,7 @@ export class DockerfileTemplateResolver implements Resolver {
 	public resolve(
 		bundle: Bundle,
 		specifiedDockerfilePath = 'Dockerfile',
-		additionalTemplateVars: Dictionary<string> = {},
+		additionalTemplateVars: Record<string, string> = {},
 	) {
 		// Generate the variables to replace
 		const vars: DockerfileTemplate.TemplateVariables = {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "balena-lint -t ./tsconfig.test.json lib/ typings/ test/ && tsc --noEmit",
-    "lint-fix": "balena-lint -t ./tsconfig.test.json --fix lib/ typings/ test/",
+    "lint": "balena-lint -t ./tsconfig.test.json lib/ test/ && tsc --noEmit",
+    "lint-fix": "balena-lint -t ./tsconfig.test.json --fix lib/ test/",
     "copy": "ncp lib/multibuild/build-secrets dist/multibuild/build-secrets --filter='build-secrets($|.Dockerfile.*)'",
     "build": "npm run clean && tsc --project ./ && npm run copy",
     "test": "npm run lint && ts-mocha --project ./tsconfig.test.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,7 @@
     "strictNullChecks": true
   },
   "include": [
-    "lib/**/*.ts",
-    "typings/**/*.d.ts"
+    "lib/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,7 +7,6 @@
   },
   "include": [
     "lib/**/*.ts",
-    "typings/**/*.d.ts",
     "test/**/*.ts"
   ],
 }

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -1,3 +1,0 @@
-interface Dictionary<T> {
-	[key: string]: T;
-}


### PR DESCRIPTION
This reduces the number of custom typings we maintain/need to know about

Change-type: patch